### PR TITLE
change quote usage

### DIFF
--- a/src/ArffFile.php
+++ b/src/ArffFile.php
@@ -5,9 +5,8 @@ namespace Cocur\Arff;
 use Cocur\Arff\Column\ColumnInterface;
 
 /**
- * ArffWriter
+ * ArffWriter.
  *
- * @package   Cocur\Arff
  * @author    Florian Eckerstorfer
  * @copyright 2015 Florian Eckerstorfer
  */
@@ -105,7 +104,7 @@ class ArffFile
         foreach ($this->columns as $name => $column) {
             $value = $row[$name];
             if (preg_match('/\s|,|;/', $value)) {
-                $value = sprintf('"%s"', $value);
+                $value = sprintf("'%s'", $value);
             }
             $processedRow[] = $value;
         }

--- a/src/Column/NominalColumn.php
+++ b/src/Column/NominalColumn.php
@@ -1,12 +1,10 @@
 <?php
 
-
 namespace Cocur\Arff\Column;
 
 /**
- * NominalColumn
+ * NominalColumn.
  *
- * @package   Cocur\Arff\Column
  * @author    Florian Eckerstorfer
  * @copyright 2015 Florian Eckerstorfer
  */
@@ -62,6 +60,26 @@ class NominalColumn extends AbstractColumn
      */
     public function render()
     {
-        return sprintf('@ATTRIBUTE %s {%s}', $this->getName(), implode(',', $this->getClasses()));
+        return sprintf('@ATTRIBUTE %s {%s}', $this->getName(), $this->renderClasses());
+    }
+    
+    /**
+     * @return string
+     */
+    private function renderClasses()
+    {
+        $classes = $this->getClasses();
+        $strClass = '';
+
+        for ($i = 0; $i < count($classes); ++$i) {
+            $class = $classes[$i];
+
+            if (preg_match('/\s|,|;/', $class)) {
+                $class = sprintf("'%s'", $class);
+            }
+            $classes[$i] = $class;
+        }
+
+        return implode(',', $classes);
     }
 }

--- a/tests/ArffFileTest.php
+++ b/tests/ArffFileTest.php
@@ -7,9 +7,8 @@ use org\bovigo\vfs\vfsStream;
 use PHPUnit_Framework_TestCase;
 
 /**
- * ArffFileTest
+ * ArffFileTest.
  *
- * @package   Cocur\Arff
  * @author    Florian Eckerstorfer
  * @copyright 2015 Florian Eckerstorfer
  * @group     unit
@@ -85,11 +84,11 @@ class ArffFileTest extends PHPUnit_Framework_TestCase
 @ATTRIBUTE d date "yyyy-MM-dd HH:mm:ss"
 
 @DATA
-hello,1.5,x,"2015-07-17 16:12:30"
-"hello world",1.5,"x y",?
+hello,1.5,x,'2015-07-17 16:12:30'
+'hello world',1.5,'x y',?
 hello,?,z,?
-"hello,world",?,?,?
-"hello;world",?,?,?
+'hello,world',?,?,?
+'hello;world',?,?,?
 
 EOF;
 
@@ -134,19 +133,19 @@ EOF;
         $file = new ArffFile('foobar');
         $file->addColumn(Mockery::mock('Cocur\Arff\Column\ColumnInterface', [
             'getName' => 'a',
-            'render'  => '@ATTRIBUTE a string',
+            'render' => '@ATTRIBUTE a string',
         ]));
         $file->addColumn(Mockery::mock('Cocur\Arff\Column\ColumnInterface', [
             'getName' => 'b',
-            'render'  => '@ATTRIBUTE b numeric',
+            'render' => '@ATTRIBUTE b numeric',
         ]));
         $file->addColumn(Mockery::mock('Cocur\Arff\Column\ColumnInterface', [
             'getName' => 'c',
-            'render'  => '@ATTRIBUTE c {x,y,z}',
+            'render' => '@ATTRIBUTE c {x,y,z}',
         ]));
         $file->addColumn(Mockery::mock('Cocur\Arff\Column\ColumnInterface', [
             'getName' => 'd',
-            'render'  => '@ATTRIBUTE d date "yyyy-MM-dd HH:mm:ss"',
+            'render' => '@ATTRIBUTE d date "yyyy-MM-dd HH:mm:ss"',
         ]));
         $file->addData(['a' => 'hello', 'b' => 1.5, 'c' => 'x', 'd' => '2015-07-17 16:12:30']);
         $file->addData(['a' => 'hello world', 'b' => 1.5, 'c' => 'x y']);


### PR DESCRIPTION
Use single quote instead of double quotes to enclosure space-containing word in NominalColumn and Data.
I am using arff file generated by WEKA 3.8 as a comparison. I found that they are using single quote instead of double quotes to quote space-containing word. I've tested the generated arff file using this fork and it works well with WEKA 3.8.