### PR TITLE
Supports Weka generated ARFF files

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -32,7 +32,7 @@ class Reader
      */
     protected function parseName($line)
     {
-        if (preg_match('/^@RELATION ([a-zA-Z-_]+)$/i', $line, $matches)) {
+        if (preg_match('/^@RELATION ([a-zA-Z-_\.\/\d]+)$/i', $line, $matches)) {
             return $matches[1];
         }
 
@@ -97,6 +97,11 @@ class Reader
                     $row[$columns[$columnNames[$j]]->getName()] = trim($value, "'");
                 }
             }
+
+            if (count($row) != count($columnNames)) {
+                continue; // malformed, probably and empty line
+            }
+
             $document->addData($row);
         }
     }

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -19,7 +19,7 @@ class ReaderTest extends TestCase
         $reader = new Reader();
         $root = vfsStream::setup('fixtures');
         $content = <<<EOF
-@RELATION foobar
+@RELATION weka.foobar-something/version1
 
 @ATTRIBUTE a string
 @ATTRIBUTE b numeric
@@ -29,11 +29,11 @@ class ReaderTest extends TestCase
 @ATTRIBUTE f Numeric
 
 @DATA
-hello,1.5,x,'2015-07-17 16:12:30'
-'hello world',1.5,'x y',?
-hello,?,z,?
-'hello,world',?,?,?
-'hello;world',?,?,?
+hello,1.5,x,'2015-07-17 16:12:30','Ernesto',12
+'hello world',1.5,'x y',?,?,?
+hello,?,z,?,Jack,55
+'hello,world',?,?,?,?,?
+'hello;world',?,?,?,?,?
 
 EOF;
         $file = new vfsStreamFile('test.arff', 0777);
@@ -42,7 +42,7 @@ EOF;
         $document = $reader->readFile($root->url().'/test.arff');
 
         $columns = $document->getColumns();
-        $this->assertEquals('foobar', $document->getName());
+        $this->assertEquals('weka.foobar-something/version1', $document->getName());
 
         $this->assertEquals('a', $columns['a']->getName());
         $this->assertEquals('string', $columns['a']->getType());
@@ -85,5 +85,7 @@ EOF;
 
         $this->assertEquals('hello,world', $data[3]['a']);
         $this->assertEquals('hello;world', $data[4]['a']);
+
+        $this->assertEquals(5, count($data));
     }
 }


### PR DESCRIPTION
* Support more generic relation names (as the ones generated by weka)
* Drops malformed lines (especially empty ones)

This enables the support of files generate by Weka like:
```
java -classpath deps/weka-3-8-2/weka.jar weka.filters.supervised.attribute.AddClassification -serialized someweka.model -classification -remove-old-class -i in.arff -o out.arff -c last 2>&1
```